### PR TITLE
Initial pathName commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ GoogleSignin.configure({
   forceCodeForRefreshToken: true, // [Android] related to `serverAuthCode`, read the docs link below *.
   accountName: '', // [Android] specifies an account name on the device that should be used
   iosClientId: '<FROM DEVELOPER CONSOLE>', // [iOS] optional, if you want to specify the client ID of type iOS (otherwise, it is taken from GoogleService-Info.plist)
+  iosServicePathName: '', // [iOS] optional, if you renamed your GoogleService-Info file, new name here, e.g. GoogleService-Info-Staging
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ GoogleSignin.configure({
   forceCodeForRefreshToken: true, // [Android] related to `serverAuthCode`, read the docs link below *.
   accountName: '', // [Android] specifies an account name on the device that should be used
   iosClientId: '<FROM DEVELOPER CONSOLE>', // [iOS] optional, if you want to specify the client ID of type iOS (otherwise, it is taken from GoogleService-Info.plist)
-  iosServicePathName: '', // [iOS] optional, if you renamed your GoogleService-Info file, new name here, e.g. GoogleService-Info-Staging
+  googleServicePlistPath: '', // [iOS] optional, if you renamed your GoogleService-Info file, new name here, e.g. GoogleService-Info-Staging
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,12 @@ export interface ConfigureParams {
   iosClientId?: string;
 
   /**
+   * If you want to specify a different bundle path name for the GoogleService-Info, e.g. GoogleService-Info-Staging
+   */
+
+  iosServicePathName?: string;
+
+  /**
    * Must be true if you wish to access user APIs on behalf of the user from
    * your own server
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,7 +62,7 @@ export interface ConfigureParams {
    * If you want to specify a different bundle path name for the GoogleService-Info, e.g. GoogleService-Info-Staging
    */
 
-  iosServicePathName?: string;
+  googleServicePlistPath?: string;
 
   /**
    * Must be true if you wish to access user APIs on behalf of the user from

--- a/index.js.flow
+++ b/index.js.flow
@@ -4,6 +4,7 @@ import { typeof View } from 'react-native';
 
 export type ConfigureParams = $ReadOnly<{|
   iosClientId?: string,
+  iosServicePathName?: string,
   offlineAccess?: boolean,
   webClientId?: string,
   scopes?: string[],

--- a/index.js.flow
+++ b/index.js.flow
@@ -4,7 +4,7 @@ import { typeof View } from 'react-native';
 
 export type ConfigureParams = $ReadOnly<{|
   iosClientId?: string,
-  iosServicePathName?: string,
+  googleServicePlistPath?: string,
   offlineAccess?: boolean,
   webClientId?: string,
   scopes?: string[],

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSString *pathName = options[@"iosServicePathName"] ? options[@"iosServicePathName"] : @"GoogleService-Info";
+  NSString *pathName = options[@"googleServicePlistPath"] ? options[@"googleServicePlistPath"] : @"GoogleService-Info";
 
   NSString *path = [[NSBundle mainBundle] pathForResource:pathName ofType:@"plist"];
 

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSString *pathName = options[@"iosServicePathName"] || @"GoogleService-Info";
+  NSString *pathName = options[@"iosServicePathName"] ? options[@"iosServicePathName"] : @"GoogleService-Info";
 
   NSString *path = [[NSBundle mainBundle] pathForResource:pathName ofType:@"plist"];
 

--- a/ios/RNGoogleSignin/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin/RNGoogleSignin.m
@@ -57,7 +57,9 @@ RCT_EXPORT_METHOD(configure:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
-  NSString *path = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
+  NSString *pathName = options[@"iosServicePathName"] || @"GoogleService-Info";
+
+  NSString *path = [[NSBundle mainBundle] pathForResource:pathName ofType:@"plist"];
 
   if (!options[@"iosClientId"] && !path) {
     NSString* message = @"RNGoogleSignin: failed to determine clientID - GoogleService-Info.plist was not found and iosClientId was not provided. To fix this error: if you have GoogleService-Info.plist file (usually downloaded from firebase) place it into the project as seen in the iOS guide. Otherwise pass iosClientId option to configure()";


### PR DESCRIPTION
This PR introduces the possibility of changing the name of the GoogleService-Info on iOS. This is particularly useful for people with multiple environments, as they may need to include different files for different environments, but still wants to keep the GoogleService-Info file as the central point of information.