### PR TITLE
feat(android): get webClientId automatically

### DIFF
--- a/android/src/main/java/com/reactnativegooglesignin/RNGoogleSigninModule.java
+++ b/android/src/main/java/com/reactnativegooglesignin/RNGoogleSigninModule.java
@@ -125,11 +125,18 @@ public class RNGoogleSigninModule extends ReactContextBaseJavaModule {
             final Promise promise
     ) {
         final ReadableArray scopes = config.hasKey("scopes") ? config.getArray("scopes") : Arguments.createArray();
-        final String webClientId = config.hasKey("webClientId") ? config.getString("webClientId") : null;
+        String webClientId = config.hasKey("webClientId") ? config.getString("webClientId") : null;
         final boolean offlineAccess = config.hasKey("offlineAccess") && config.getBoolean("offlineAccess");
         final boolean forceCodeForRefreshToken = config.hasKey("forceCodeForRefreshToken") && config.getBoolean("forceCodeForRefreshToken");
         final String accountName = config.hasKey("accountName") ? config.getString("accountName") : null;
         final String hostedDomain = config.hasKey("hostedDomain") ? config.getString("hostedDomain") : null;
+      
+        if (webClientId == null) {
+            int id = getCurrentActivity().getResources().getIdentifier("default_web_client_id", "string", getCurrentActivity().getPackageName());
+            if (id != 0) {
+                webClientId = getCurrentActivity().getResources().getString(id);
+            }
+        }
 
         GoogleSignInOptions options = getSignInOptions(createScopesArray(scopes), webClientId, offlineAccess, forceCodeForRefreshToken, accountName, hostedDomain);
         _apiClient = GoogleSignIn.getClient(getReactApplicationContext(), options);


### PR DESCRIPTION
### Motivation

We have for our app multiple environment configurations, so we have multiple firebase projects. As the configuration for google/firebase happens on the native side it was too impractical for us to pass the `webClientId` on the JS side (the JS side has no clue about the google/firebase configuration).
We initially came to this when we mentioned that after the signing in the `idToken` was empty. We then read several issues which explained that you need to pass the `webClientId` when calling `configure`.

### Solution

During the build process, the `google-services.json` seems to get read and its content is added to the resources. We simply get the resource value for the `webClientId` from the resources, which is equivalent to the value of `client.oauth_client.client_id`.

### Concerns

I have zero knowledge about this code base or firebase/google mechanisms in general. For us, this solution works fairly well, so I thought it might do for others. But maybe I've missed a big important point somewhere 🤷 