### PR TITLE
Move implementation of RCTConvert enums into implementation file

### DIFF
--- a/ios/RCTConvert+RNGoogleSignin.h
+++ b/ios/RCTConvert+RNGoogleSignin.h
@@ -1,0 +1,9 @@
+#import <React/RCTConvert.h>
+#import <GoogleSignIn/GoogleSignIn.h>
+
+@interface RCTConvert(RNGoogleSignin)
+
++ (GIDSignInButtonStyle)GIDSignInButtonStyle:(id)json;
++ (GIDSignInButtonColorScheme)GIDSignInButtonColorScheme:(id)json;
+
+@end

--- a/ios/RCTConvert+RNGoogleSignin.m
+++ b/ios/RCTConvert+RNGoogleSignin.m
@@ -1,0 +1,16 @@
+#import "RCTConvert+RNGoogleSignin.h"
+
+@implementation RCTConvert(RNGoogleSignin)
+
+RCT_ENUM_CONVERTER(GIDSignInButtonStyle, (@{
+                                            @"standard": @(kGIDSignInButtonStyleStandard),
+                                            @"wide": @(kGIDSignInButtonStyleWide),
+                                            @"icon": @(kGIDSignInButtonStyleIconOnly),
+                                            }), kGIDSignInButtonStyleStandard, integerValue)
+
+RCT_ENUM_CONVERTER(GIDSignInButtonColorScheme, (@{
+                                                  @"dark": @(kGIDSignInButtonColorSchemeDark),
+                                                  @"light": @(kGIDSignInButtonColorSchemeLight),
+                                                  }), kGIDSignInButtonColorSchemeDark, integerValue)
+
+@end

--- a/ios/RNGoogleSignin.h
+++ b/ios/RNGoogleSignin.h
@@ -1,12 +1,5 @@
-#ifndef RN_GoogleSigning_h
-#define RN_GoogleSigning_h
-
 #import <React/RCTBridgeModule.h>
-#import <React/RCTConvert.h>
 #import <React/RCTComponent.h>
-
-#import <GoogleSignIn/GoogleSignIn.h>
-
 
 @interface RNGoogleSignin : NSObject<RCTBridgeModule>
 
@@ -15,26 +8,3 @@
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
 @end
-
-@implementation RCTConvert(GIDSignInButtonStyle)
-
-RCT_ENUM_CONVERTER(GIDSignInButtonStyle, (@{
-                                            @"standard": @(kGIDSignInButtonStyleStandard),
-                                            @"wide": @(kGIDSignInButtonStyleWide),
-                                            @"icon": @(kGIDSignInButtonStyleIconOnly),
-                                            }), kGIDSignInButtonStyleStandard, integerValue)
-
-
-@end
-
-@implementation RCTConvert(GIDSignInButtonColorScheme)
-
-RCT_ENUM_CONVERTER(GIDSignInButtonColorScheme, (@{
-                                                  @"dark": @(kGIDSignInButtonColorSchemeDark),
-                                                  @"light": @(kGIDSignInButtonColorSchemeLight),
-                                                  }), kGIDSignInButtonColorSchemeDark, integerValue)
-
-@end
-
-
-#endif

--- a/ios/RNGoogleSignin.m
+++ b/ios/RNGoogleSignin.m
@@ -1,5 +1,6 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
+#import <GoogleSignIn/GoogleSignIn.h>
 #import "RNGoogleSignin.h"
 
 @interface RNGoogleSignin ()

--- a/ios/RNGoogleSigninButtonManager.m
+++ b/ios/RNGoogleSigninButtonManager.m
@@ -1,5 +1,6 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTLog.h>
+#import "RCTConvert+RNGoogleSignin.h"
 #import "RNGoogleSignin.h"
 #import "RNGoogleSignInButton.h"
 


### PR DESCRIPTION
This caused warnings like "method '+GIDSignInButtonStyle:' in category from ... conflicts with same method from another category"

Also implementing code is not supposed to be in header files