### PR TITLE
Update GoogleSignIn dependency to support Mac Catalyst

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "GoogleSignIn", "~> 6.0.0"
+  s.dependency "GoogleSignIn", "~> 6.1.0"
 end

--- a/docs/ios-guide.md
+++ b/docs/ios-guide.md
@@ -43,6 +43,7 @@ At the end, the dependencis should be linked like in this picture (this is _with
 
 - Configure URL types in the `Info` panel (see screenshot)
   - add a URL with scheme set to your `REVERSED_CLIENT_ID` (found inside `GoogleService-Info.plist`)
+- If you need to support Mac Catalyst, you will need to enable the Keychain Sharing capability on each build target. No keychain groups need to be added.
 
 [![link config](../img/urlTypes.png)](../img/urlTypes.png?raw=true)
 


### PR DESCRIPTION
Waiting for https://github.com/google/GoogleSignIn-iOS/issues/95 to be resolved.