### PR TITLE
Updating GoogleSignIn pod version to 6.1.0

### DIFF
--- a/docs/ios-guide.md
+++ b/docs/ios-guide.md
@@ -12,7 +12,7 @@ Again, we offer two ways to do this: with and without Cocoapods. Note that we re
 
 ##### With Cocoapods
 
-install the Google Signin SDK with [CocoaPods](https://cocoapods.org/): add `pod 'GoogleSignIn', '~> 6.0.2'` in your Podfile and run `pod install`
+install the Google Signin SDK with [CocoaPods](https://cocoapods.org/): add `pod 'GoogleSignIn', '~> 6.1.0'` in your Podfile and run `pod install`
 
 First time using cocoapods ? [check this out](./how-cocoapods.md)
 


### PR DESCRIPTION
Updated the GoogleSignIn pod version to 6.1.0 as latest package has dependency on it. 

<img width="1119" alt="Screenshot 2022-03-03 at 4 43 14 PM" src="https://user-images.githubusercontent.com/2439128/156553884-0b831eb9-1f51-4f3d-9436-33499d4fdc96.png">



This PR fixes #1036 
