### PR TITLE
Updated the Version Number of the Podfile Statement

### DIFF
--- a/docs/ios-guide.md
+++ b/docs/ios-guide.md
@@ -12,7 +12,7 @@ Again, we offer two ways to do this: with and without Cocoapods. Note that we re
 
 ##### With Cocoapods
 
-install the Google Signin SDK with [CocoaPods](https://cocoapods.org/): add `pod 'GoogleSignIn', '~> 6.1.0'` in your Podfile and run `pod install`
+install the Google Signin SDK with [CocoaPods](https://cocoapods.org/): add `pod 'GoogleSignIn', '~> 6.2.2'` in your Podfile and run `pod install`
 
 First time using cocoapods ? [check this out](./how-cocoapods.md)
 


### PR DESCRIPTION
Changed `pod 'GoogleSignIn', '~> 6.1.0'` to `pod 'GoogleSignIn', '~> 6.2.2'`. 

The reference to the old version throws the following error:  
```nodejs
RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`) was resolved to 8.0.0, which depends on GoogleSignIn (~> 6.2.2)
```