### PR TITLE
fix: remove incorrect expo information

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "GoogleSignIn", "~> 6.2.2"
+  s.dependency "GoogleSignIn", "~> 6.2"
 end

--- a/src/GoogleSignin.ts
+++ b/src/GoogleSignin.ts
@@ -17,7 +17,7 @@ class GoogleSignin {
   constructor() {
     if (__DEV__ && !RNGoogleSignin) {
       console.error(
-        `RN GoogleSignin native module is not correctly linked. Please read the readme, setup and troubleshooting instructions carefully or try manual linking. If you're using Expo, please use expo-google-sign-in. This is because Expo does not support custom native modules.`,
+        `RN GoogleSignin native module is not correctly linked. Please read the readme, setup and troubleshooting instructions carefully or try manual linking.`,
       );
     }
   }


### PR DESCRIPTION
expo is supported via a config plugin, so the error is incorrect