### PR TITLE
feat: update iOS target to 13 for Expo Adapter

### DIFF
--- a/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/ios/ExpoAdapterGoogleSignIn.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '12.0'
+  s.platform       = :ios, '13.0'
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/react-native-google-signin/google-signin.git', :tag => "v#{package['version']}" }
   s.static_framework = true


### PR DESCRIPTION
Expo 47 bumps the iOS target to iOS 13, build fails with the current version of 12.