### PR TITLE
chore: specify GoogleSignIn version range for expo

### DIFF
--- a/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/ios/ExpoAdapterGoogleSignIn.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
-  s.dependency 'GoogleSignIn'
+  s.dependency "GoogleSignIn", "~> 6.2"
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
would be nice to keep it in one place instead of two (2 podpecs now) but this is good enough for now