### PR TITLE
Update minimum deployment version to keep up with Expo

### DIFF
--- a/RNGoogleSignin.podspec
+++ b/RNGoogleSignin.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "13.0" }
   s.source       = { :git => "https://github.com/react-native-google-signin/google-signin.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
Just updating this podspec file wasn't enough on my project: https://github.com/react-native-google-signin/google-signin/pull/1108

I realize that changing the minimum deployment version is a big decision, so feel free to close this PR if it's not in-line with your plans. 

On my project, I'm using a post_install hook in cocoapods as a workaround for now

```ruby
post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
    end
  end
end
```