### PR TITLE
Update the route link for Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Please visit https://developers.google.com/identity/protocols/googlescopes or ht
 
 ## Troubleshooting
 
-Please see the troubleshooting section in the [Android guide](docs/android-guide.md) and [iOS guide](docs/ios-guide.md).
+Please see the troubleshooting section in the [Android guide](https://react-native-google-signin.github.io/docs/setting-up/android) and [iOS guide](https://react-native-google-signin.github.io/docs/setting-up/ios).
 
 ## Licence
 


### PR DESCRIPTION
- It is annoying to get 404 while reading the doc. As there seem to be website for documentation, just updated the link


![Screenshot 2024-03-21 at 2 57 41 PM](https://github.com/react-native-google-signin/google-signin/assets/46732700/ddec3627-0254-4f76-84e7-b6bb3bf964ca)
