### PR TITLE
feat: new js api

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,22 +7,22 @@ People discussing in this GitHub organization are expected to interact in ways t
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Giving and accepting constructive feedback
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Giving and accepting constructive feedback
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
 
 Examples of unacceptable behavior include:
 
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Making unfounded statements that put people or projects in bad light
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Making unfounded statements that put people or projects in bad light
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1204,7 +1204,7 @@ PODS:
     - React-Core
     - React-jsi
   - ReactTestApp-Resources (1.0.0-dev)
-  - RNGoogleSignin (11.0.1):
+  - RNGoogleSignin (12.2.1):
     - GoogleSignIn (~> 7.1)
     - React-Core
   - SocketRocket (0.7.0)
@@ -1460,7 +1460,7 @@ SPEC CHECKSUMS:
   ReactNativeHost: a365307db1ece0c4825b9d0f8b35de1bb2a61b0a
   ReactTestApp-DevSupport: f845db38b4b4ce8d341f8acdba934ee85ed3d7b2
   ReactTestApp-Resources: 3171451c647ad9dbb037146693ea8046a58cb638
-  RNGoogleSignin: b78e49de632b5982a4c7d42d2e6b59cc4b8493c0
+  RNGoogleSignin: 08dc4ba7eac2096c7fecfe109f0950fa4683c803
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: b9a182ab00cf25926e7f79657d08c5d23c2d03b0
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -80,15 +80,31 @@ type StatusCodes = $ReadOnly<{
 
 declare export var statusCodes: StatusCodes;
 
-// the functions are not static in fact, but the module exports a
-// singleton instance of the class; not the class itself
-// using static keyword works well for this case
+export type SignInSuccessResponse = {|
+  type: 'success';
+  data: User;
+|};
+export type CancelledResponse = {|
+  type: 'cancelled';
+  data: null;
+|};
+export type NoSavedCredentialFound = {|
+  type: 'noSavedCredentialFound';
+  data: null;
+|};
+export type SignInResponse = SignInSuccessResponse | CancelledResponse;
+export type SignInSilentlyResponse =
+  | SignInSuccessResponse
+  | NoSavedCredentialFound;
+
+// the functions are not static class functions in fact
+// but using static keyword works well for this case
 declare export class GoogleSignin {
   static hasPlayServices: (params?: HasPlayServicesParams) => Promise<boolean>;
   static configure: (params?: ConfigureParams) => void;
-  static signInSilently: () => Promise<User>;
-  static signIn: (params?: SignInParams) => Promise<User>;
-  static addScopes: (params: AddScopesParams) => Promise<User | null>;
+  static signInSilently: () => Promise<SignInSilentlyResponse>;
+  static signIn: (params?: SignInParams) => Promise<SignInResponse>;
+  static addScopes: (params: AddScopesParams) => Promise<SignInResponse | null>;
   static signOut: () => Promise<null>;
   static revokeAccess: () => Promise<null>;
   static hasPreviousSignIn: () => boolean;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -5,7 +5,7 @@ import {
   GoogleSigninButton,
   isErrorWithCode,
 } from '@react-native-google-signin/google-signin';
-import { mockUserInfo } from '../../jest/setup';
+import { mockGoogleSignInResponse, mockUserInfo } from '../../jest/setup';
 
 describe('GoogleSignin', () => {
   describe('sanity checks for exported mocks', () => {
@@ -20,7 +20,9 @@ describe('GoogleSignin', () => {
 
     it('original sign in', async () => {
       expect(GoogleSignin.hasPreviousSignIn()).toBe(true);
-      expect(await GoogleSignin.signIn()).toStrictEqual(mockUserInfo);
+      expect(await GoogleSignin.signIn()).toStrictEqual(
+        mockGoogleSignInResponse,
+      );
       expect(GoogleSignin.getCurrentUser()).toStrictEqual(mockUserInfo);
       expect(await GoogleSignin.signOut()).toBeNull();
       expect(GoogleSigninButton).toBeInstanceOf(Function);

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -23,6 +23,9 @@ describe('GoogleSignin', () => {
       expect(await GoogleSignin.signIn()).toStrictEqual(
         mockGoogleSignInResponse,
       );
+      expect(await GoogleSignin.signInSilently()).toStrictEqual(
+        mockGoogleSignInResponse,
+      );
       expect(GoogleSignin.getCurrentUser()).toStrictEqual(mockUserInfo);
       expect(await GoogleSignin.signOut()).toBeNull();
       expect(GoogleSigninButton).toBeInstanceOf(Function);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,9 @@
+export const cancelledResult = Object.freeze({
+  type: 'cancelled',
+  data: null,
+});
+
+export const noSavedCredentialFoundResult = Object.freeze({
+  type: 'noSavedCredentialFound',
+  data: null,
+});

--- a/src/errors/errorCodes.ts
+++ b/src/errors/errorCodes.ts
@@ -5,7 +5,12 @@ const {
   IN_PROGRESS,
   PLAY_SERVICES_NOT_AVAILABLE,
   SIGN_IN_REQUIRED,
+  SCOPES_ALREADY_GRANTED,
 } = NativeModule.getConstants();
+
+export const SIGN_IN_REQUIRED_CODE = SIGN_IN_REQUIRED;
+export const SIGN_IN_CANCELLED_CODE = SIGN_IN_CANCELLED;
+export const ios_only_SCOPES_ALREADY_GRANTED = SCOPES_ALREADY_GRANTED;
 
 /**
  * @group Constants

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -36,7 +36,7 @@ export const isErrorWithCode = (error: any): error is NativeModuleError => {
  * ```
  */
 export function isCancelledResponse(
-  response: SignInResponse, // should this signature be included too?
+  response: SignInResponse,
 ): response is CancelledResponse {
   return response.type === 'cancelled';
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,0 +1,84 @@
+import type {
+  CancelledResponse,
+  NativeModuleError,
+  NoSavedCredentialFound,
+} from './types';
+import type {
+  SignInResponse,
+  SignInSilentlyResponse,
+} from './signIn/GoogleSignin';
+
+/**
+ * TypeScript helper to check if an object has the `code` property.
+ * This is used to avoid `as` casting when you access the `code` property on errors returned by the module.
+ */
+export const isErrorWithCode = (error: any): error is NativeModuleError => {
+  // to account for https://github.com/facebook/react-native/issues/41950
+  // fixed in https://github.com/facebook/react-native/commit/9525074a194b9cf2b7ef8ed270978e3f7f2c41f7 0.74
+  const isNewArchErrorIOS = typeof error === 'object' && error != null;
+  return (error instanceof Error || isNewArchErrorIOS) && 'code' in error;
+};
+
+/**
+ * TypeScript helper to check if a response is a `cancelled` response. This is the same as checking if the `response.type === "cancelled"`.
+ *
+ * Use this if you prefer to use a function instead of comparing with a raw string.
+ *
+ * It supports both One Tap and Original Google Sign In responses.
+ *
+ * @example
+ * ```ts
+ * const response = await GoogleOneTapSignIn.createAccount();
+ *
+ * if (isCancelledResponse(response)) {
+ *   // handle cancelled response
+ * }
+ * ```
+ */
+export function isCancelledResponse(
+  response: SignInResponse, // should this signature be included too?
+): response is CancelledResponse {
+  return response.type === 'cancelled';
+}
+
+/**
+ * TypeScript helper to check if a response is a `noSavedCredentialFound` response. This is the same as checking if the `response.type === "noSavedCredentialFound"`.
+ *
+ * Use this if you prefer to use a function instead of comparing with a raw string.
+ *
+ * It supports both One Tap and Original Google Sign In responses.
+ *
+ * @example
+ * ```ts
+ * const response = await GoogleOneTapSignIn.signIn();
+ *
+ * if (isNoSavedCredentialFoundResponse(response)) {
+ *   // the case when no user was previously signed in
+ * }
+ * ```
+ */
+export function isNoSavedCredentialFoundResponse(
+  response: SignInSilentlyResponse,
+): response is NoSavedCredentialFound {
+  return response.type === 'noSavedCredentialFound';
+}
+
+/**
+ * TypeScript helper to check if a response is a `cancelled` response. This is the same as checking if the `response.type === "cancelled"`.
+ *
+ * Use this if you prefer to use a function instead of comparing with a raw string.
+ *
+ * It supports both One Tap and Original Google Sign In responses.
+ *
+ * @example
+ * ```ts
+ * const response = await GoogleOneTapSignIn.createAccount();
+ *
+ * if (isSuccessResponse(response)) {
+ *   // handle user signed in
+ * }
+ * ```
+ */
+export function isSuccessResponse(response: SignInResponse): boolean {
+  return response.type === 'success';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-export { GoogleSignin } from './signIn/GoogleSignin';
+export {
+  GoogleSignin,
+  type SignInSilentlyResponse,
+  type SignInResponse,
+  type SignInSuccessResponse,
+} from './signIn/GoogleSignin';
 export { statusCodes } from './errors/errorCodes';
 
 export {
@@ -7,3 +12,4 @@ export {
 } from './buttons/GoogleSigninButton';
 
 export * from './types';
+export * from './functions';

--- a/src/signIn/GoogleSignin.ts
+++ b/src/signIn/GoogleSignin.ts
@@ -24,6 +24,11 @@ function configure(options: ConfigureParams = {}): void {
   if (options.offlineAccess && !options.webClientId) {
     throw new Error('RNGoogleSignin: offline use requires server web ClientID');
   }
+  if ('androidClientId' in options) {
+    console.error(
+      'RNGoogleSignIn: `androidClientId` is not a valid configuration parameter, please remove it.',
+    );
+  }
 
   configPromise = NativeModule.configure(options);
 }

--- a/src/signIn/GoogleSignin.ts
+++ b/src/signIn/GoogleSignin.ts
@@ -107,7 +107,7 @@ async function addScopes(
     }
     // on Android, the user returned in onActivityResult() will contain only the scopes added, not the ones present previously
     // we work around it by calling signInSilently() which returns the user object with all scopes
-    // @ts-expect-error `no_saved_credential_found` is not possible here, because we just added scopes
+    // @ts-expect-error `noSavedCredentialFound` is not possible here, because we just added scopes
     return signInSilently();
   }
 }

--- a/src/signIn/GoogleSignin.ts
+++ b/src/signIn/GoogleSignin.ts
@@ -1,13 +1,22 @@
 import { Platform } from 'react-native';
-import type {
+import {
   AddScopesParams,
+  CancelledResponse,
   ConfigureParams,
   GetTokensResponse,
   HasPlayServicesParams,
+  NoSavedCredentialFound,
   SignInParams,
   User,
 } from '../types';
 import { NativeModule } from '../spec/NativeGoogleSignin';
+import {
+  ios_only_SCOPES_ALREADY_GRANTED,
+  SIGN_IN_REQUIRED_CODE,
+} from '../errors/errorCodes';
+import { noSavedCredentialFoundResult } from '../constants';
+import { translateCancellationError } from '../translateNativeRejection';
+import { isErrorWithCode } from '../functions';
 
 let configPromise = Promise.resolve();
 
@@ -19,45 +28,109 @@ function configure(options: ConfigureParams = {}): void {
   configPromise = NativeModule.configure(options);
 }
 
-async function signIn(options: SignInParams = {}): Promise<User> {
+/**
+ * The response object when the user signs in successfully.
+ *
+ * @group Original Google sign in
+ * */
+export type SignInSuccessResponse = {
+  type: 'success';
+  /**
+   * The user details.
+   * */
+  data: User;
+};
+
+/**
+ * @group Original Google sign in
+ * */
+export type SignInResponse = SignInSuccessResponse | CancelledResponse;
+
+async function signIn(options: SignInParams = {}): Promise<SignInResponse> {
   await configPromise;
-  return (await NativeModule.signIn(options)) as User;
+  try {
+    const user = (await NativeModule.signIn(options)) as User;
+    return createSuccessResponse(user);
+  } catch (err) {
+    return translateCancellationError(err);
+  }
 }
 
 async function hasPlayServices(
-  options: HasPlayServicesParams = { showPlayServicesUpdateDialog: true },
+  options?: HasPlayServicesParams,
 ): Promise<boolean> {
   if (Platform.OS === 'ios') {
     return true;
   } else {
-    if (options && options.showPlayServicesUpdateDialog === undefined) {
-      throw new Error(
-        'RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in options object for `hasPlayServices`',
-      );
+    if (process.env.NODE_ENV !== 'production') {
+      if (options && options.showPlayServicesUpdateDialog === undefined) {
+        throw new Error(
+          'RNGoogleSignin: Missing property `showPlayServicesUpdateDialog` in options object for `hasPlayServices`',
+        );
+      }
     }
     return NativeModule.playServicesAvailable(
-      options.showPlayServicesUpdateDialog,
+      options?.showPlayServicesUpdateDialog !== false,
     );
   }
 }
 
-async function addScopes(options: AddScopesParams): Promise<User | null> {
+async function addScopes(
+  options: AddScopesParams,
+): Promise<SignInResponse | null> {
   if (Platform.OS === 'ios') {
-    return NativeModule.addScopes(options) as Promise<User | null>;
+    try {
+      const user = (await NativeModule.addScopes(options)) as User | null;
+      if (!user) {
+        return null;
+      }
+      return createSuccessResponse(user);
+    } catch (err) {
+      if (
+        isErrorWithCode(err) &&
+        err.code === ios_only_SCOPES_ALREADY_GRANTED
+      ) {
+        // return the scopes that are already granted
+        const user = GoogleSignin.getCurrentUser();
+        if (!user) {
+          return null;
+        }
+        return createSuccessResponse(user);
+      }
+      return translateCancellationError(err);
+    }
   } else {
+    // false if no user is signed in
     const hasUser = await NativeModule.addScopes(options);
     if (!hasUser) {
       return null;
     }
     // on Android, the user returned in onActivityResult() will contain only the scopes added, not the ones present previously
     // we work around it by calling signInSilently() which returns the user object with all scopes
+    // @ts-expect-error `no_saved_credential_found` is not possible here, because we just added scopes
     return signInSilently();
   }
 }
 
-async function signInSilently(): Promise<User> {
-  await configPromise;
-  return NativeModule.signInSilently() as Promise<User>;
+/**
+ * The response object for calling `signInSilently`. Either the user details are available (without user interaction) or there was no saved credential found.
+ * @group Original Google sign in
+ * */
+export type SignInSilentlyResponse =
+  | SignInSuccessResponse
+  | NoSavedCredentialFound;
+
+async function signInSilently(): Promise<SignInSilentlyResponse> {
+  try {
+    await configPromise;
+    const user = (await NativeModule.signInSilently()) as User;
+    return createSuccessResponse(user);
+  } catch (err) {
+    if (isErrorWithCode(err) && err.code === SIGN_IN_REQUIRED_CODE) {
+      return noSavedCredentialFoundResult;
+    }
+    throw err;
+  }
 }
 
 async function signOut(): Promise<null> {
@@ -98,6 +171,11 @@ async function getTokens(): Promise<GetTokensResponse> {
     };
   }
 }
+
+const createSuccessResponse = (data: User): SignInSuccessResponse => ({
+  type: 'success',
+  data,
+});
 
 /**
  * The entry point of the Google Sign In API, exposed as `GoogleSignin`.

--- a/src/signIn/GoogleSignin.web.ts
+++ b/src/signIn/GoogleSignin.web.ts
@@ -8,7 +8,7 @@ import type {
 } from '../types';
 import { statusCodes } from '../errors/errorCodes.web';
 const errorMessage =
-  'RNGoogleSignIn: you are calling a not-implemented method on web platform. Web support is only available to sponsors.' +
+  'RNGoogleSignIn: you are calling a not-implemented method on web platform. Web support is only available to sponsors. \n' +
   'If you are a sponsor, please follow the installation instructions carefully to obtain the implementation.';
 
 const logNotImplementedError = () => {

--- a/src/signIn/GoogleSignin.web.ts
+++ b/src/signIn/GoogleSignin.web.ts
@@ -8,7 +8,9 @@ import type {
 } from '../types';
 import { statusCodes } from '../errors/errorCodes.web';
 const errorMessage =
-  'RNGoogleSignIn: you are calling a not-implemented method on web platform.';
+  'RNGoogleSignIn: you are calling a not-implemented method on web platform. Web support is only available to sponsors.' +
+  'If you are a sponsor, please follow the installation instructions carefully to obtain the implementation.';
+
 const logNotImplementedError = () => {
   console.warn(errorMessage);
 };

--- a/src/translateNativeRejection.ts
+++ b/src/translateNativeRejection.ts
@@ -1,0 +1,16 @@
+import { isErrorWithCode } from './functions';
+import { cancelledResult } from './constants';
+import { SIGN_IN_CANCELLED_CODE } from './errors/errorCodes';
+
+/**
+ * Since the introduction of a new JS api, the native rejections need to be processed in JS layer.
+ *
+ * This is easier than reworking 2 native modules
+ **/
+export function translateCancellationError(e: unknown) {
+  if (isErrorWithCode(e) && e.code === SIGN_IN_CANCELLED_CODE) {
+    return cancelledResult;
+  } else {
+    throw e;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,11 +132,21 @@ export interface NativeModuleError extends Error {
 }
 
 /**
- * TypeScript helper to check if an object has the `code` property.
- * This is used to avoid `as` casting when you access the `code` property on errors returned by the module.
- */
-export const isErrorWithCode = (error: any): error is NativeModuleError => {
-  // to account for https://github.com/facebook/react-native/issues/41950
-  const isNewArchErrorIOS = typeof error === 'object' && error != null;
-  return (error instanceof Error || isNewArchErrorIOS) && 'code' in error;
+ * The response object when the user cancels the flow for any operation that requires user interaction.
+ *
+ * On the Web, this is also returned while [cooldown period](https://developers.google.com/identity/gsi/web/guides/features#exponential_cooldown) is active.
+ * Detecting the cooldown period itself is not possible on the Web for user privacy reasons.
+ * On Android, it can be detected via `ONE_TAP_START_FAILED`
+ * */
+export type CancelledResponse = {
+  type: 'cancelled';
+  data: null;
+};
+
+/**
+ * The response to calling One Tap's `signIn` and Original Google Sign In's `signInSilently` when no user was previously signed in.
+ * */
+export type NoSavedCredentialFound = {
+  type: 'noSavedCredentialFound';
+  data: null;
 };


### PR DESCRIPTION
Why: the current API is a bit clumsy when it comes to handling errors and reacting to them

ex: to handle the sign in cancellation, you're required to implement this in the catch block. It's not unlikely that the code handling cancellation will be empty:

```js
// OLD CODE
} catch (error) {
    if (isErrorWithCode(error)) {
      switch (error.code) {
        case statusCodes.SIGN_IN_CANCELLED:
          // sign in was cancelled
          break;
    } else {
      // an error that's not related to google sign in occurred
    }
  }
```

The changes in this PR mean that only "real errors" are propagated to the `catch` block. Cancellation is handled in the `try` block:

```js
// NEW CODE
    const { type, data } = await GoogleSignin.signIn();
    if (type === 'success') {
      setState({ userInfo: data });
    } else {
      // sign in was cancelled by user
    }
```

Same change is present for `addScopes` and `signInSilently` - `statusCodes.SIGN_IN_REQUIRED` was removed and is now handled as follows:

```js
    const { type, data } = await GoogleSignin.signInSilently();
    if (isSuccessResponse(response)) {
      setState({ userInfo: response.data });
    } else if (isNoSavedCredentialFoundResponse(response)) {
      // user has not signed in yet
    }
```

This makes the api a little nicer to work with and the non-success cases are more explicitly visible in the API.

additionally, fixes #1070
