### PR TITLE
fix: change isSuccessResponse to a type predicate

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   SignInResponse,
   SignInSilentlyResponse,
+  SignInSuccessResponse,
 } from './signIn/GoogleSignin';
 
 /**
@@ -64,7 +65,7 @@ export function isNoSavedCredentialFoundResponse(
 }
 
 /**
- * TypeScript helper to check if a response is a `cancelled` response. This is the same as checking if the `response.type === "cancelled"`.
+ * TypeScript helper to check if a response is a `cancelled` response. This is the same as checking if the `response.type === "success"`.
  *
  * Use this if you prefer to use a function instead of comparing with a raw string.
  *
@@ -79,6 +80,6 @@ export function isNoSavedCredentialFoundResponse(
  * }
  * ```
  */
-export function isSuccessResponse(response: SignInResponse): boolean {
+export function isSuccessResponse(response: SignInResponse): response is SignInSuccessResponse {
   return response.type === 'success';
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -80,6 +80,8 @@ export function isNoSavedCredentialFoundResponse(
  * }
  * ```
  */
-export function isSuccessResponse(response: SignInResponse): response is SignInSuccessResponse {
+export function isSuccessResponse(
+  response: SignInResponse,
+): response is SignInSuccessResponse {
   return response.type === 'success';
 }


### PR DESCRIPTION
## Description

This PR updates `isSuccessResponse` method to a type predicate.

This change makes code consistent with `isCancelledResponse`. 

This enables better user experience with type system.
### Before
```ts
import { GoogleSignin, isSuccessResponse } from '@react-native-google-signin/google-signin'

const response = await GoogleSignin.signIn()

if (isSuccessResponse(response)) {
  // response type is SignInResponse, response.data type is User | null
}
```

### After 
```ts
import { GoogleSignin, isSuccessResponse } from '@react-native-google-signin/google-signin'

const response = await GoogleSignin.signIn()

if (isSuccessResponse(response)) {
  // response type is SignInSuccessResponse, response.data type is User
}
```
