### PR TITLE
fix: use jest.mock with correct paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:mock": "tsc --build jest",
     "build:plugin": "tsc --build plugin",
     "clean:plugin": "expo-module clean plugin",
-    "test": "jest",
+    "test": "SILENCE_MOCK_NOT_FOUND=true jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prepare": "bob build && yarn build:plugin && yarn build:mock && husky install",


### PR DESCRIPTION
when using the mocks that are shipped with the module, they would previously not mock the correct path