### PR TITLE
feat: improve support for RN 0.77

### DIFF
--- a/.github/footer.hbs
+++ b/.github/footer.hbs
@@ -1,4 +1,4 @@
-Tip: there's a [paid version of the package](https://react-native-google-signin.github.io/docs/install) with a [new implementation](https://react-native-google-signin.github.io/docs/one-tap), advanced [security features](https://react-native-google-signin.github.io/docs/security), support for [web](https://react-native-google-signin.github.io/docs/setting-up/web), and more features.
+⭐ **Tip**: there's a [paid version of the package](https://universal-sign-in.com/#pricing) with a [new implementation](https://react-native-google-signin.github.io/docs/one-tap), advanced [security features](https://react-native-google-signin.github.io/docs/security), support for [web](https://react-native-google-signin.github.io/docs/setting-up/web), and more features.
 
 {{#if noteGroups}}
 {{#each noteGroups}}

--- a/ios/RNGoogleSignInButton.h
+++ b/ios/RNGoogleSignInButton.h
@@ -1,16 +1,7 @@
 #import <GoogleSignIn/GoogleSignIn.h>
 #import <React/RCTComponent.h>
 
-#ifdef RCT_NEW_ARCH_ENABLED
-  #import <React/RCTViewComponentView.h>
-#endif // RCT_NEW_ARCH_ENABLED
-
-@interface RNGoogleSignInButton :
-#ifdef RCT_NEW_ARCH_ENABLED
-  RCTViewComponentView
-#else
-  GIDSignInButton
-#endif // RCT_NEW_ARCH_ENABLED
+@interface RNGoogleSignInButton : GIDSignInButton
 
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;
 

--- a/ios/RNGoogleSignInButton.mm
+++ b/ios/RNGoogleSignInButton.mm
@@ -1,76 +1,10 @@
-#import <React/RCTLog.h>
 #import "RNGoogleSignInButton.h"
 
-#ifdef RCT_NEW_ARCH_ENABLED
-
-#import <React/RCTConversions.h>
-#import <React/RCTFabricComponentsPlugins.h>
-#import <react/renderer/components/RNGoogleSignInCGen/ComponentDescriptors.h>
-#import <react/renderer/components/RNGoogleSignInCGen/Props.h>
-#import <react/renderer/components/RNGoogleSignInCGen/RCTComponentViewHelpers.h>
-
-using namespace facebook::react;
-
-@interface RNGoogleSignInButton () <RCTRNGoogleSigninButtonViewProtocol>
-#else
 @interface RNGoogleSignInButton ()
-#endif // RCT_NEW_ARCH_ENABLED
+
 @end
 
 @implementation RNGoogleSignInButton {
-  GIDSignInButton *_button;
 }
-
-#ifdef RCT_NEW_ARCH_ENABLED
-+ (ComponentDescriptorProvider)componentDescriptorProvider
-{
-  return concreteComponentDescriptorProvider<RNGoogleSigninButtonComponentDescriptor>();
-}
-
-- (instancetype)initWithFrame:(CGRect)frame
-{
-  if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNGoogleSigninButtonProps>();
-    _props = defaultProps;
-
-    _button = [[GIDSignInButton alloc] initWithFrame:self.bounds];
-    [_button addTarget:self action:@selector(onButtonPress:) forControlEvents:UIControlEventTouchUpInside];
-    self.contentView = _button;
-  }
-  return self;
-}
-
--(void)onButtonPress:(RNGoogleSignInButton *)sender
-{
-  std::dynamic_pointer_cast<const RNGoogleSigninButtonEventEmitter>(_eventEmitter)
-  ->onPress(RNGoogleSigninButtonEventEmitter::OnPress{});
-}
-
-- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
-{
-  const auto &oldViewProps = *std::static_pointer_cast<RNGoogleSigninButtonProps const>(_props);
-  const auto &newViewProps = *std::static_pointer_cast<RNGoogleSigninButtonProps const>(props);
-
-  if (oldViewProps.disabled != newViewProps.disabled) {
-    _button.enabled = !newViewProps.disabled;
-  }
-  if (oldViewProps.color != newViewProps.color) {
-    _button.colorScheme = newViewProps.color == RNGoogleSigninButtonColor::Dark ? kGIDSignInButtonColorSchemeDark : kGIDSignInButtonColorSchemeLight;
-  }
-  if (oldViewProps.size != newViewProps.size) {
-    _button.style = (GIDSignInButtonStyle) newViewProps.size;
-  }
-
-  [super updateProps:props oldProps:oldProps];
-}
-#endif
 
 @end
-
-
-#ifdef RCT_NEW_ARCH_ENABLED
-Class<RCTComponentViewProtocol> RNGoogleSigninButtonCls(void)
-{
-  return RNGoogleSignInButton.class;
-}
-#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNGoogleSignInButtonComponentView.h
+++ b/ios/RNGoogleSignInButtonComponentView.h
@@ -1,0 +1,14 @@
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <React/RCTViewComponentView.h>
+#import <React/RCTConversions.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNGoogleSignInButtonComponentView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/ios/RNGoogleSignInButtonComponentView.mm
+++ b/ios/RNGoogleSignInButtonComponentView.mm
@@ -1,0 +1,72 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTLog.h>
+#import <GoogleSignIn/GoogleSignIn.h>
+#import "RNGoogleSignInButtonComponentView.h"
+
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
+#import <react/renderer/components/RNGoogleSignInCGen/ComponentDescriptors.h>
+#import <react/renderer/components/RNGoogleSignInCGen/Props.h>
+#import <react/renderer/components/RNGoogleSignInCGen/RCTComponentViewHelpers.h>
+
+using namespace facebook::react;
+
+@interface RNGoogleSignInButtonComponentView () <RCTRNGoogleSigninButtonViewProtocol>
+
+@end
+
+@implementation RNGoogleSignInButtonComponentView {
+  GIDSignInButton *_button;
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<RNGoogleSigninButtonComponentDescriptor>();
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if ((self = [super initWithFrame:frame])) {
+    static const auto defaultProps = std::make_shared<const RNGoogleSigninButtonProps>();
+    _props = defaultProps;
+
+    _button = [[GIDSignInButton alloc] initWithFrame:self.bounds];
+    [_button addTarget:self action:@selector(onButtonPress:) forControlEvents:UIControlEventTouchUpInside];
+    self.contentView = _button;
+  }
+  return self;
+}
+
+-(void)onButtonPress:(GIDSignInButton *)sender
+{
+  std::dynamic_pointer_cast<const RNGoogleSigninButtonEventEmitter>(_eventEmitter)
+  ->onPress(RNGoogleSigninButtonEventEmitter::OnPress{});
+}
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldViewProps = *std::static_pointer_cast<RNGoogleSigninButtonProps const>(_props);
+  const auto &newViewProps = *std::static_pointer_cast<RNGoogleSigninButtonProps const>(props);
+
+  if (oldViewProps.disabled != newViewProps.disabled) {
+    _button.enabled = !newViewProps.disabled;
+  }
+  if (oldViewProps.color != newViewProps.color) {
+    _button.colorScheme = newViewProps.color == RNGoogleSigninButtonColor::Dark ? kGIDSignInButtonColorSchemeDark : kGIDSignInButtonColorSchemeLight;
+  }
+  if (oldViewProps.size != newViewProps.size) {
+    _button.style = (GIDSignInButtonStyle) newViewProps.size;
+  }
+
+  [super updateProps:props oldProps:oldProps];
+}
+
+@end
+
+
+Class<RCTComponentViewProtocol> RNGoogleSigninButtonCls(void)
+{
+  return RNGoogleSignInButtonComponentView.class;
+}
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNGoogleSigninButtonManager.mm
+++ b/ios/RNGoogleSigninButtonManager.mm
@@ -1,6 +1,6 @@
 #import <React/RCTViewManager.h>
 #import "RCTConvert+RNGoogleSignin.h"
-#import "RNGoogleSigninButtonPaper.h"
+#import "RNGoogleSignInButton.h"
 
 @interface RNGoogleSigninButtonManager : RCTViewManager
 @end

--- a/ios/RNGoogleSigninButtonPaper.h
+++ b/ios/RNGoogleSigninButtonPaper.h
@@ -1,8 +1,0 @@
-#import <GoogleSignIn/GoogleSignIn.h>
-#import <React/RCTComponent.h>
-
-@interface RNGoogleSignInButton : GIDSignInButton
-
-@property (nonatomic, copy) RCTBubblingEventBlock onPress;
-
-@end

--- a/package.json
+++ b/package.json
@@ -137,6 +137,11 @@
     "jsSrcsDir": "src/spec",
     "android": {
       "javaPackageName": "com.reactnativegooglesignin"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNGoogleSignInButton": "RNGoogleSignInButtonComponentView"
+      }
     }
   },
   "packageManager": "yarn@4.1.1",


### PR DESCRIPTION
RN 0.77 seems to not like the old button implementation. This PR just moves the old code into `ios/RNGoogleSignInButtonComponentView.mm`. The `*ComponentView` pattern can be seen in many other fabric-ready libraries.