### PR TITLE
chore: removing the commonjs path from mockModulePaths

### DIFF
--- a/jest/setup.tsx
+++ b/jest/setup.tsx
@@ -83,9 +83,7 @@ jest.mock('../src/spec/NativeGoogleSignin', () => mockFactory());
 
 // the following are for jest testing outside of the library, where the paths are different
 // alternative is to use moduleNameMapper in user space
-const mockModulePaths = [
-  '../../../lib/module/spec/NativeGoogleSignin',
-];
+const mockModulePaths = ['../../../lib/module/spec/NativeGoogleSignin'];
 mockModulePaths.forEach((path) => {
   try {
     require.resolve(path);

--- a/jest/setup.tsx
+++ b/jest/setup.tsx
@@ -84,7 +84,6 @@ jest.mock('../src/spec/NativeGoogleSignin', () => mockFactory());
 // the following are for jest testing outside of the library, where the paths are different
 // alternative is to use moduleNameMapper in user space
 const mockModulePaths = [
-  '../../../lib/commonjs/spec/NativeGoogleSignin',
   '../../../lib/module/spec/NativeGoogleSignin',
 ];
 mockModulePaths.forEach((path) => {


### PR DESCRIPTION
Remove the commonjs path from `mockModulePaths` in the jest setup (since commonjs isn’t in the lib output) to resolve the Unable to resolve `../../../lib/commonjs/spec/NativeGoogleSignin` warning during testing.