### PR TITLE
redundant URL handling when Firebase swizzling enabled

### DIFF
--- a/expo/ios/ExpoAdapterGoogleSignIn/GoogleSignInAppDelegate.swift
+++ b/expo/ios/ExpoAdapterGoogleSignIn/GoogleSignInAppDelegate.swift
@@ -1,10 +1,41 @@
 #if canImport(ExpoModulesCore) 
 import ExpoModulesCore
 import GoogleSignIn
+import Foundation
 
 public class GoogleSignInAppDelegate: ExpoAppDelegateSubscriber {
   public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    // If Firebase is configured and swizzling is enabled, GULAppDelegateSwizzler (from GoogleUtilities)
+    // will handle the URL. Calling GIDSignIn.sharedInstance.handle(url) here would be redundant and
+    // can cause a crash (fatal error: OIDExternalUserAgentSession already completed).
+    if isFirebaseSwizzlingEnabled() {
+      return false
+    }
     return GIDSignIn.sharedInstance.handle(url)
+  }
+
+  private func isFirebaseSwizzlingEnabled() -> Bool {
+    // Check if FirebaseAppDelegateProxyEnabled is explicitly disabled
+    // If the key is missing, it defaults to true (enabled)
+    if let proxyEnabled = Bundle.main.object(forInfoDictionaryKey: "FirebaseAppDelegateProxyEnabled") as? Bool, !proxyEnabled {
+      return false
+    }
+
+    // Check if FIRApp class is available (FirebaseCore is linked)
+    guard let firAppClass = NSClassFromString("FIRApp") as? NSObject.Type else {
+      return false
+    }
+
+    // Check if Firebase is configured
+    // If Firebase is linked but not configured (e.g. early in startup or intentionally unused),
+    // the swizzler might not be active or we shouldn't rely on it.
+    let selector = NSSelectorFromString("defaultApp")
+    if firAppClass.responds(to: selector),
+       firAppClass.perform(selector) != nil {
+      return true
+    }
+
+    return false
   }
 }
 #endif


### PR DESCRIPTION
## Summary
This PR fixes a crash (An OAuth redirect was sent to a OIDExternalUserAgentSession after it already completed) that occurs when using the package together with Firebase.

The crash happens because the URL is handled twice:
1. First by `GULAppDelegateSwizzler` (Firebase/GoogleUtilities).
2. Then by `ExpoAdapterGoogleSignIn`'s `GoogleSignInAppDelegate`.
This double invocation causes `GIDSignIn` to try resuming an already completed session.

## Changes
Modified `GoogleSignInAppDelegate.swift` to conditionally skip calling `GIDSignIn.sharedInstance.handle(url) `if:
1. Firebase Core is linked (`FIRApp` class exists).
2. Firebase is configured (`[FIRApp defaultApp] `is not nil).
3. Swizzling is enabled (`FirebaseAppDelegateProxyEnabled` is not false).

This ensures that when Firebase is handling the URL via swizzling, the Expo adapter steps back, preventing the crash while maintaining support for non-Firebase environments.

## Repro
I was able to reproduce it on physical device only! I had to set-up Firebase! 

I called the `signIn` method 2 times, and canceled the first one redirection. 
Than, the second one is opened up the Safari (stand alone) app, and when the sign-in was successful and navigated back to the initiator app, it's crashed. 
