### PR TITLE
fix(ios): catch exceptions in open url

### DIFF
--- a/expo/ios/ExpoAdapterGoogleSignIn/GoogleSignInAppDelegate.swift
+++ b/expo/ios/ExpoAdapterGoogleSignIn/GoogleSignInAppDelegate.swift
@@ -1,10 +1,23 @@
-#if canImport(ExpoModulesCore) 
+#if canImport(ExpoModulesCore)
 import ExpoModulesCore
 import GoogleSignIn
 
 public class GoogleSignInAppDelegate: ExpoAppDelegateSubscriber {
-  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+  private func handleSignInURL(_ url: URL) throws -> Bool {
+    // marked as `throws` to make compiler warning go away
     return GIDSignIn.sharedInstance.handle(url)
+  }
+
+  public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    do {
+      // As documented here:
+      // https://github.com/google/GoogleSignIn-iOS/issues/547#issuecomment-3658139632
+      // added both to handle the bug and as a precaution.
+      return try handleSignInURL(url)
+    } catch {
+      NSLog("[RNGoogleSignIn] Failed to handle sign-in URL: %@", String(describing: error))
+      return false
+    }
   }
 }
 #endif


### PR DESCRIPTION
(Only concerns expo) this adds a `do + catch` around the `GIDSignIn.sharedInstance.handle` method which is known to throw errors in v9 of the native google sign in SDK (which is the subject of this issue: https://github.com/google/GoogleSignIn-iOS/issues/547#issuecomment-3658139632)