### PR TITLE
fix: android avoid NPE in GoogleSigninButton on RN 0.79 old architecture

### DIFF
--- a/android/src/main/java/com/reactnativegooglesignin/RNGoogleSigninButtonViewManager.java
+++ b/android/src/main/java/com/reactnativegooglesignin/RNGoogleSigninButtonViewManager.java
@@ -64,7 +64,7 @@ public class RNGoogleSigninButtonViewManager extends SimpleViewManager<SignInBut
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             return mDelegate;
         } else {
-            return null;
+            return super.getDelegate();
         }
     }
 


### PR DESCRIPTION
Fixes an Android crash when rendering `GoogleSigninButton` on React Native 0.79+ with newArchEnabled=false (old architecture).

On RN 0.79+, Android view property updates in this path call `delegate.setProperty(...)` during view creation/update. Returning `null` causes a `NullPointerException`.

**Issue details:**
https://github.com/react-native-google-signin/google-signin/issues/1490

**Reproduction:**
https://github.com/kashmiry/rn79GoogleSigninCrash