### PR TITLE
feat: support nonce in iOS original sign-in

### DIFF
--- a/ios/RNGoogleSignin.mm
+++ b/ios/RNGoogleSignin.mm
@@ -130,12 +130,13 @@ RCT_EXPORT_METHOD(signIn:(NSDictionary *)options
       }
 
       NSString* hint = options[@"loginHint"];
+      NSString* nonce = options[@"nonce"];
       NSArray* scopes = self.scopes;
 
 #if DEBUG
     @try {
 #endif
-      [GIDSignIn.sharedInstance signInWithPresentingViewController:presentingViewController hint:hint additionalScopes:scopes completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+      [GIDSignIn.sharedInstance signInWithPresentingViewController:presentingViewController hint:hint additionalScopes:scopes nonce:nonce completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
         [self handleCompletion:signInResult withError:error withResolver:resolve withRejector:reject fromCallsite:@"signIn"];
       }];
 #if DEBUG

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,15 @@ export type SignInParams = {
    * [See docs here](https://developers.google.com/identity/sign-in/ios/reference/Classes/GIDSignIn#-signinwithpresentingviewcontroller:hint:completion:)
    */
   loginHint?: string;
+  /**
+   * iOS only. Optional nonce value to include in the ID token.
+   *
+   * Pass the value your identity provider expects in the token's `nonce` claim.
+   * For providers that compare against a hash of a raw nonce, pass the hashed
+   * nonce here and the raw nonce to the provider when verifying the ID token.
+   * [See docs here](https://developers.google.com/identity/sign-in/ios/reference/Classes/GIDSignIn#-signinwithpresentingviewcontroller:hint:additionalscopes:nonce:completion:)
+   */
+  nonce?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds an optional `nonce` parameter to Original Google Sign-In on iOS and forwards it to `GIDSignIn`'s nonce-aware API.

This is backwards compatible:
- callers that do not pass `nonce` keep the existing behavior (`nil` is forwarded)
- Android behavior is unchanged
- the JS API only gains an optional field

## Why

The iOS Google Sign-In SDK supports passing a custom nonce to include in the ID token. Exposing it here lets apps keep server-side nonce verification enabled when using identity providers that require a matching nonce during ID-token verification.

Refs:
- #1176
- #1461
- google/GoogleSignIn-iOS#402
- openid/AppAuth-iOS#788

## Test plan

- `git diff --check`
- Verified this matches the existing local patch used in an Expo/RN app for Supabase `signInWithIdToken` nonce verification on iOS.
