### PR TITLE
fix(expo): raise ExpoAdapterGoogleSignIn iOS deployment target for Expo SDK 56

### DIFF
--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platform       = :ios, '16.4'
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/react-native-google-signin/google-signin.git', :tag => "v#{package['version']}" }
   s.static_framework = true

--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -5,7 +5,7 @@ package = JSON.parse(File.read(File.join(__dir__, '..', '..', 'package.json')))
 # ExpoAdapterGoogleSignIn imports ExpoModulesCore, so its iOS deployment target
 # must be >= ExpoModulesCore's. That floor changes per Expo SDK (SDK 56 = 16.4),
 # so derive it from the installed ExpoModulesCore.podspec instead of hardcoding.
-ios_deployment_target = '15.1'
+ios_deployment_target = '15.1' # fallback if derivation fails; iOS floor shared by every supported Expo SDK
 begin
   expo_modules_core_dir = File.dirname(
     `node --print "require.resolve('expo-modules-core/package.json', { paths: ['#{__dir__}'] })"`.strip

--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -2,21 +2,19 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', '..', 'package.json')))
 
-# ExpoAdapterGoogleSignIn imports ExpoModulesCore, so its iOS deployment target
-# must be >= ExpoModulesCore's. That floor changes per Expo SDK (SDK 56 = 16.4),
-# so derive it from the installed ExpoModulesCore.podspec instead of hardcoding.
-ios_deployment_target = '15.1' # fallback if derivation fails; iOS floor shared by every supported Expo SDK
+# Read ExpoModulesCore's iOS deployment target from its installed podspec so this
+# adapter always matches it (the value is raised per Expo SDK, e.g. 16.4 on SDK 56).
+ios_deployment_target = '15.1' # fallback if the podspec cannot be read
 begin
   expo_modules_core_dir = File.dirname(
     `node --print "require.resolve('expo-modules-core/package.json', { paths: ['#{__dir__}'] })"`.strip
   )
-  ios_platform = Pod::Specification
-    .from_file(File.join(expo_modules_core_dir, 'ExpoModulesCore.podspec'))
-    .available_platforms
-    .find { |platform| platform.name == :ios }
-  ios_deployment_target = ios_platform.deployment_target.to_s if ios_platform
+  podspec_text = File.read(File.join(expo_modules_core_dir, 'ExpoModulesCore.podspec'))
+  ios_target = podspec_text[/:ios\s*(?:=>|,)\s*['"]([\d.]+)['"]/, 1]
+  raise 'no iOS platform found in ExpoModulesCore.podspec' unless ios_target
+  ios_deployment_target = ios_target
 rescue => e
-  message = "ExpoAdapterGoogleSignIn: could not derive iOS deployment target from ExpoModulesCore (#{e}); using #{ios_deployment_target}"
+  message = "ExpoAdapterGoogleSignIn: could not read iOS deployment target from ExpoModulesCore (#{e}); using #{ios_deployment_target}"
   defined?(Pod::UI) ? Pod::UI.warn(message) : warn(message)
 end
 

--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -2,6 +2,24 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', '..', 'package.json')))
 
+# ExpoAdapterGoogleSignIn imports ExpoModulesCore, so its iOS deployment target
+# must be >= ExpoModulesCore's. That floor changes per Expo SDK (SDK 56 = 16.4),
+# so derive it from the installed ExpoModulesCore.podspec instead of hardcoding.
+ios_deployment_target = '15.1'
+begin
+  expo_modules_core_dir = File.dirname(
+    `node --print "require.resolve('expo-modules-core/package.json', { paths: ['#{__dir__}'] })"`.strip
+  )
+  ios_platform = Pod::Specification
+    .from_file(File.join(expo_modules_core_dir, 'ExpoModulesCore.podspec'))
+    .available_platforms
+    .find { |platform| platform.name == :ios }
+  ios_deployment_target = ios_platform.deployment_target.to_s if ios_platform
+rescue => e
+  message = "ExpoAdapterGoogleSignIn: could not derive iOS deployment target from ExpoModulesCore (#{e}); using #{ios_deployment_target}"
+  defined?(Pod::UI) ? Pod::UI.warn(message) : warn(message)
+end
+
 Pod::Spec.new do |s|
   s.name           = 'ExpoAdapterGoogleSignIn'
   s.version        = package['version']
@@ -10,7 +28,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '16.4'
+  s.platform       = :ios, ios_deployment_target
   s.swift_version  = '5.4'
   s.source         = { :git => 'https://github.com/react-native-google-signin/google-signin.git', :tag => "v#{package['version']}" }
   s.static_framework = true


### PR DESCRIPTION
## Summary

`ExpoAdapterGoogleSignIn` (the Expo module under `expo/ios/`) imports `ExpoModulesCore`, but its podspec hardcoded `s.platform = :ios, '13.4'`.

`ExpoModulesCore`'s iOS deployment target is raised per Expo SDK (SDK 56 sets it to 16.4). Swift cannot import a module built for a higher deployment target into a target built for a lower one, so iOS builds that use the Expo adapter on SDK 56 fail:

```
GoogleSignInAppDelegate.swift:2:8 Compiling for iOS 15.1, but module 'ExpoModulesCore'
has a minimum deployment target of iOS 16.4
```

`13.4` was also below the iOS minimum (15.1) of every Expo SDK in this package's `expo: ">=52.0.40"` peer range, so the value was already stale.

## Change

The podspec reads `ExpoModulesCore`'s iOS deployment target from its installed `ExpoModulesCore.podspec` and uses that value, so one release stays correct across Expo SDK versions (SDK 56 resolves 16.4, earlier SDKs resolve their own lower value):

```ruby
ios_deployment_target = '15.1' # fallback if the podspec cannot be read
begin
  expo_modules_core_dir = File.dirname(
    `node --print "require.resolve('expo-modules-core/package.json', { paths: ['#{__dir__}'] })"`.strip
  )
  podspec_text = File.read(File.join(expo_modules_core_dir, 'ExpoModulesCore.podspec'))
  ios_target = podspec_text[/:ios\s*(?:=>|,)\s*['"]([\d.]+)['"]/, 1]
  raise 'no iOS platform found in ExpoModulesCore.podspec' unless ios_target
  ios_deployment_target = ios_target
rescue => e
  message = "ExpoAdapterGoogleSignIn: could not read iOS deployment target from ExpoModulesCore (#{e}); using #{ios_deployment_target}"
  defined?(Pod::UI) ? Pod::UI.warn(message) : warn(message)
end
```

The value is read from the podspec **text** rather than evaluated with `Pod::Specification.from_file`. `ExpoModulesCore.podspec` is an imperative script (it requires `react_native_pods` and calls `get_folly_config`), so evaluating it only works inside a fully set-up `pod install` and raises `Pod::DSLError` under `pod ipc spec` / `pod spec lint`. Reading the file text has no such dependency and works in every context; any failure warns loudly and falls back rather than silently using a wrong value.

`RNGoogleSignin.podspec` is unaffected (Objective-C, does not import `ExpoModulesCore`).

## Test plan

- `pod ipc spec expo/ios/ExpoAdapterGoogleSignIn.podspec` on an Expo SDK 56 install resolves `platforms.ios` to `16.4` (matches `ExpoModulesCore`), with no warning.
- `npx expo prebuild -p ios` then `pod install` on an Expo SDK 56 app; build succeeds with `ExpoAdapterGoogleSignIn` compiling against `ExpoModulesCore`.
