### PR TITLE
fix(expo): declare AppCheckCore modular dependencies

### DIFF
--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency "GoogleSignIn", package["GoogleSignInPodVersion"]
+
+  # Expo gives direct dependencies of Expo modules modular headers. AppCheckCore,
+  # pulled in by GoogleSignIn, imports these Objective-C pods from Swift.
   s.dependency 'GoogleUtilities/Environment'
   s.dependency 'GoogleUtilities/UserDefaults'
   s.dependency 'RecaptchaInterop'

--- a/expo/ios/ExpoAdapterGoogleSignIn.podspec
+++ b/expo/ios/ExpoAdapterGoogleSignIn.podspec
@@ -18,6 +18,9 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency "GoogleSignIn", package["GoogleSignInPodVersion"]
+  s.dependency 'GoogleUtilities/Environment'
+  s.dependency 'GoogleUtilities/UserDefaults'
+  s.dependency 'RecaptchaInterop'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
## Summary

Fix Expo iOS prebuild failures with the current `GoogleSignIn` / `AppCheckCore` pod graph by declaring the pods that need modular headers from the Expo adapter podspec.

## Why

Fresh Expo 56 installs with `@react-native-google-signin/google-signin@16.1.2` can resolve `GoogleSignIn 9.2.0` and `AppCheckCore 11.3.0`. In Expo's default static CocoaPods setup, CocoaPods then fails because `AppCheckCore` is a Swift pod that depends on `GoogleUtilities` and `RecaptchaInterop`, which do not define modules unless modular headers are enabled.

Expo autolinking already enables modular headers for direct dependencies of Expo modules with native code. The Expo adapter is this package's Swift Expo module, so declaring the specific `AppCheckCore` dependency pods there lets Expo apply its normal modular-header handling without requiring generated Podfile edits or an `AppCheckCore` version pin.

## What Changed

Added these direct dependencies to `ExpoAdapterGoogleSignIn.podspec` so Expo marks them modular:

- `GoogleUtilities/Environment`
- `GoogleUtilities/UserDefaults`
- `RecaptchaInterop`

## Validation

Created a fresh Expo 56 repro app:

```sh
npx create-expo-app@latest rngsi-expo56-repro --template blank-typescript --yes
cd rngsi-expo56-repro
npm install @react-native-google-signin/google-signin@16.1.2
npx expo prebuild --clean --platform ios
```

Baseline failed during pod install:

```text
The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`,
which do not define modules.
```

After applying this patch:

```sh
rm -rf ios/Pods ios/Podfile.lock ios/build/DerivedData
npx expo prebuild --platform ios --no-install
cd ios && pod install --repo-update
xcodebuild -workspace rngsiexpo56repro.xcworkspace \
  -scheme rngsiexpo56repro \
  -configuration Debug \
  -sdk iphonesimulator \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -derivedDataPath build/DerivedData \
  build
```

Results:

- `pod install` succeeds.
- `xcodebuild` succeeds.
- The resulting lockfile keeps `GoogleSignIn 9.2.0`, `AppCheckCore 11.3.0`, and `RecaptchaInterop 101.0.0`.

Closes #1517.
